### PR TITLE
splitting out remote node logs

### DIFF
--- a/chef/cookbooks/logging/recipes/server.rb
+++ b/chef/cookbooks/logging/recipes/server.rb
@@ -27,6 +27,13 @@ service "rsyslog" do
   action [ :enable, :start ]
 end
 
+directory "/var/log/nodes" do
+  owner "root"
+  group "root"
+  mode "0644"
+  action :create
+end
+
 template "/etc/rsyslog.d/10-crowbar-server.conf" do
   owner "root"
   group "root"

--- a/chef/cookbooks/logging/templates/default/rsyslog.server.erb
+++ b/chef/cookbooks/logging/templates/default/rsyslog.server.erb
@@ -7,6 +7,10 @@ $InputTCPServerRun 514
 $ModLoad imudp
 $UDPServerRun 514
 
+# split remote logs by hostname
+$template DynaFile,"/var/log/nodes/%HOSTNAME%.log"
+*.* -?DynaFile
+
 <% @external_servers.each do |external_server| -%>
 *.* @@<%= external_server %>
 <% end -%>


### PR DESCRIPTION
i found it easier to troubleshoot nodes by splitting out their logs into separate files based on their hostname, as opposed to digging through /var/log/messages.  this commit creates the dir /var/log/nodes/ and configures rsyslog to send each nodes logs to their own file in /var/log/nodes/%HOSTNAME%.log.
