### PR TITLE
DNS fixes (alias support and rh/ubuntu fixes) + Role by state configuration [17/26]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-logging.json
+++ b/chef/data_bags/crowbar/bc-template-logging.json
@@ -9,6 +9,10 @@
   "deployment": {
     "logging": {
       "crowbar-revision": 0,
+      "element_states": {
+        "logging-server": [ "readying", "ready", "applying" ],
+        "logging-client": [ "readying", "ready", "applying" ]
+      },
       "elements": {},
       "element_order": [
         [ "logging-server", "logging-client" ]

--- a/chef/data_bags/crowbar/bc-template-logging.schema
+++ b/chef/data_bags/crowbar/bc-template-logging.schema
@@ -32,6 +32,16 @@
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
+            "element_states": {
+              "type": "map",
+              "mapping": {
+                = : {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
             "elements": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
This allows for the DNS barclamp to work correctly in ubuntu and redhat.

Update the barclamps to have element_states for mapping their roles to states for when to execute.

 chef/data_bags/crowbar/bc-template-logging.json   |    4 ++++
 chef/data_bags/crowbar/bc-template-logging.schema |   10 ++++++++++
 2 files changed, 14 insertions(+), 0 deletions(-)
