### PR TITLE
Fix naming convention & move export buttons [2/6]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -30,12 +30,12 @@ crowbar:
 
 nav:
   utils:
-    log_export: utils_barclamp_path(:controller=>'logging')
+    logging_export: utils_export_path(:controller=>'logging')
 
 locale_additions:
   en:
     nav:
-      log_export: Log Export
+      logging_export: Log Export
     barclamp:
       logging: 
         edit_attributes: 

--- a/crowbar_framework/app/controllers/logging_controller.rb
+++ b/crowbar_framework/app/controllers/logging_controller.rb
@@ -18,7 +18,7 @@ class LoggingController < BarclampController
     @service_object = LoggingService.new logger
   end
   
-  def utils
+  def export
     ctime=Time.now.strftime("%Y%m%d-%H%M%S")
     @file = "crowbar-logs-#{ctime}.tar.bz2"
     pid = fork do


### PR DESCRIPTION
This request has 2 parts:
1) change the name of the class feature to "family" so that
   it does not create confusion for Ruby
2) make it so that export functions are buttons not menu items

 crowbar.yml                                        |    4 ++--
 .../app/controllers/logging_controller.rb          |    2 +-
 2 files changed, 3 insertions(+), 3 deletions(-)
