### PR TITLE
Add online mode for the provisioner and experimental online-install functionality [1/10]

### DIFF
--- a/chef/cookbooks/logging/recipes/server.rb
+++ b/chef/cookbooks/logging/recipes/server.rb
@@ -49,6 +49,13 @@ directory "/var/log/nodes" do
   action :create
 end
 
+directory "/etc/rsyslog.d" do
+  owner "root"
+  group "root"
+  mode "0644"
+  action :create
+end
+
 template "/etc/rsyslog.d/10-crowbar-server.conf" do
   owner "root"
   group "root"


### PR DESCRIPTION
This pull request series add 2 new features to Crowbar:

 1: Online mode for the provisioner.
    This enables the provisioner to be able to update deb/rpm/gem
    packages from sources on the Internet.

```
See README.package-updates for details on how this works and how
to enable it.
```

 2: Experimental full online-install mode.
    This leverages the infrastructure added for the provisioner to
    allow for installation of an admin node starting with a basic OS
    install and a checkout of the main Crowbar repository.  This is
    mainly useful right node for development purposes, and is under
    active development.  Most things work, but expect weird corner
    cases.

```
See README.online-install for more details.
```
