### PR TITLE
Moving dynamic docs to use database [1/7]

### DIFF
--- a/crowbar_framework/doc/logging.yml
+++ b/crowbar_framework/doc/logging.yml
@@ -13,4 +13,4 @@ crowbar+book-barclamps:
   logging+logging
                 
 crowbar+book-licenses:
-  loggin+logging-licenses
+  logging+logging-licenses


### PR DESCRIPTION
This is some work that fixes the dynamic doc system that was in place
by moving the indexs to the database.

May require you to rake db:create & rake db:migrate!

The initial call to the /docs will read and generate the index.

 crowbar_framework/doc/logging.yml |   33 +++++++++++++--------------------
 1 files changed, 13 insertions(+), 20 deletions(-)
