### PR TITLE
Move the crowbar.yml layout to v2 [15/27]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -23,7 +23,7 @@ barclamp:
     - crowbar
 
 crowbar:
-  layout: 1
+  layout: 2
   order: 40
   run_order: 40
   chef_order: 40

--- a/crowbar_framework/doc/default/logging/barclamp-info.md
+++ b/crowbar_framework/doc/default/logging/barclamp-info.md
@@ -1,0 +1,5 @@
+### Logging Barclamp
+
+This barclamp sets up a centralized server and configures the remote loggers to point to the server.
+
+

--- a/crowbar_framework/doc/default/logging/licenses.md
+++ b/crowbar_framework/doc/default/logging/licenses.md
@@ -1,0 +1,10 @@
+### Logging Barclamp Licenses
+
+This file contains information (if updated by the barclamp authors!) about the licenses that apply to your installation.
+
+The following dependencies are required:
+
+* ?
+
+
+

--- a/crowbar_framework/doc/default/logging/utils-export-logging.md
+++ b/crowbar_framework/doc/default/logging/utils-export-logging.md
@@ -1,15 +1,3 @@
-% Title:      Log Export
-  Tags:       Logging, Utilities
-  Author:     Rob Hirschfeld  
-  License:    Apache 2  
-  Copyright:  2012 by Dell, Inc  
-  Date:       May 18, 2012  
-  Parent:     crowbar/utils-export
-  Order:      100  
-  AppURL:     /utils
-  xNextTopic:  util-export
-  Format:     markdown+lhs
-
 ### Export Logs 
 
 The Logging barclamp supports exporting of the logs that are collected by Crowbar.

--- a/crowbar_framework/doc/logging.yml
+++ b/crowbar_framework/doc/logging.yml
@@ -10,7 +10,8 @@ crowbar+book-userguide:
       url:    '/utils/list'
 
 crowbar+book-barclamps:
-  logging+logging
-                
+  logging+barclamp-info
+    
 crowbar+book-licenses:
-  logging+logging-licenses
+  crowbar+licenses-crowbar-meta:
+    logging+licenses


### PR DESCRIPTION
Recent changes to add the database required us to update
the layout version.

I also added a doc skeleton while I was touching everything

 crowbar.yml                                        |    2 +-
 .../doc/default/logging/barclamp-info.md           |    5 +++++
 crowbar_framework/doc/default/logging/licenses.md  |   10 ++++++++++
 .../doc/default/logging/utils-export-logging.md    |    7 +++++++
 crowbar_framework/doc/logging.yml                  |    7 ++++---
 .../doc/logging/default/utils-export-logging.md    |   19 -------------------
 6 files changed, 27 insertions(+), 23 deletions(-)
