### PR TITLE
re-factor out intialize method in controllers [11/22]

### DIFF
--- a/crowbar_framework/app/controllers/logging_controller.rb
+++ b/crowbar_framework/app/controllers/logging_controller.rb
@@ -14,9 +14,13 @@
 # 
 
 class LoggingController < BarclampController
-  def initialize
+  before_filter :set_service_object
+ 
+  def set_service_object
     @service_object = LoggingService.new logger
   end
+
+  private :set_service_object
   
   def export
     ctime=Time.now.strftime("%Y%m%d-%H%M%S")


### PR DESCRIPTION
Fixed problem with layout rendering due to initialize method not calling super.  Refactored to use before_filter method to load @service_object and deleted initialize method.

 .../app/controllers/logging_controller.rb          |   70 ++++++++++---------
 1 files changed, 37 insertions(+), 33 deletions(-)
