### PR TITLE
Intermediate Refactoring of BarclampConfig to allow creating proposal [2/2]

### DIFF
--- a/crowbar_engine/barclamp_logging/app/controllers/barclamp_logging/application_controller.rb
+++ b/crowbar_engine/barclamp_logging/app/controllers/barclamp_logging/application_controller.rb
@@ -1,3 +1,18 @@
+# Copyright 2013, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 module BarclampLogging
   class ApplicationController < ActionController::Base
   end


### PR DESCRIPTION
This is an intermediate pull for the larger BarclampConfig.create_proposal action.

At this point, I have exposed the core model actions with tests; however
the API and CLIs needed to access this model method are NOT exposed.

There is partial progress on the APIs, but I wanted to allow others to consume the
model methods early.

WARNING: There is substantial CLEAN-UP of the proposal models out of the code base
in this pull.  That includes all the old CB1 routes.

Next steps are the hook the API into the BarclampConfig/Instance/Role.  
I have added a preminimary doc page to support this.

 .../barclamp_logging/application_controller.rb     |   15 +++++++++++++++
 1 file changed, 15 insertions(+)

Crowbar-Pull-ID: 74df267d3c10aa652b83fc328448961ee6f3f001

Crowbar-Release: development
