### PR TITLE
fix typo causing failing tests

### DIFF
--- a/crowbar_engine/barclamp_logging/app/controllers/barclamp_logging/barclamps_controller.rb
+++ b/crowbar_engine/barclamp_logging/app/controllers/barclamp_logging/barclamps_controller.rb
@@ -13,7 +13,7 @@
 # limitations under the License. 
 # 
 
-class BarclampLogging::BarclampsController < BarclampsController
+class BarclampLogging::BarclampsController < BarclampController
 
   def export
     ctime=Time.now.strftime("%Y%m%d-%H%M%S")


### PR DESCRIPTION
This is the simplest patch which fixes the test breakage; however in addition to merging, please can someone confirm that:
1. `BarclampLogging::BarclampsController` is really the right name for the derived class, and
2. `BarclampController` really is the correct superclass,

since no other class in the whole codebase fits this pattern.  Thanks.
