### PR TITLE
fix premature naming conversion to plu [1/1]

### DIFF
--- a/crowbar_engine/barclamp_logging/app/controllers/barclamp_logging/barclamps_controller.rb
+++ b/crowbar_engine/barclamp_logging/app/controllers/barclamp_logging/barclamps_controller.rb
@@ -13,7 +13,7 @@
 # limitations under the License. 
 # 
 
-class BarclampLogging::BarclampsController < BarclampsController
+class BarclampLogging::BarclampsController < BarclampController
 
   def export
     ctime=Time.now.strftime("%Y%m%d-%H%M%S")


### PR DESCRIPTION
ral

 .../barclamp_logging/barclamps_controller.rb       |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 84068418dea8cd8a38a2a696e86658532a9e71f7

Crowbar-Release: development
