### PR TITLE
Add enough default attributes to some roles to test them on an admin server. [4/7]

### DIFF
--- a/chef/roles/logging-server.rb
+++ b/chef/roles/logging-server.rb
@@ -4,6 +4,9 @@ description "Logging Servier Role - Logging master for the cloud"
 run_list(
          "recipe[logging::server]"
 )
-default_attributes()
+default_attributes "logging" => {
+  "external_servers" => [ ],
+  "config" => { "environment" => "logging-base-config" }
+}
 override_attributes()
 


### PR DESCRIPTION
Roles that have been tested:

roles for server:
   deployer-client -- OK
   bmc-nat-router -- OK
   dns-server -- tested, will need network bc.
   dns-client -- OK
   ntp-server -- OK
   logging-server -- OK
   logging-client -- not tested, cannot run with logging-server
   ipmi-discover -- not tested, need real hardware
   ipmi-configure -- not tested, need real hardware
   provisioner-base -- not tested, need working DNS and network.
   provisioner-server -- Not tested, need working DNS and network.

 chef/roles/logging-server.rb |    5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: b29260d1a62efa73a3928f732a6a1e5316498543

Crowbar-Release: development
