### PR TITLE
Enable zombie provisioner mode. [7/10]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -23,6 +23,8 @@ barclamp:
   copyright: "Dell, Inc 2013"
   api_version: "v2"
   api_version_accepts: "v2"
+  requires:
+    - chef
   member:
     - crowbar
 


### PR DESCRIPTION
This series pull requests adds just enough scaffolding to the system
to allow the provisioner to let other machines PXE boot into
Sledgehammer.  The scaffolding comes in the form of default attributes
on the roles needed to allow the provisioner to function, and fixups
to the chef recipes to allow them to operate semi-autonomously.

 crowbar.yml |    2 ++
 1 file changed, 2 insertions(+)

Crowbar-Pull-ID: b4a5d683f0e2f729f8e7cc489c8f4afaac0e6fac

Crowbar-Release: development
