### PR TITLE
Support admin node installation and node discovery on openSUSE 12.3 [2/3]

### DIFF
--- a/chef/cookbooks/logging/recipes/server.rb
+++ b/chef/cookbooks/logging/recipes/server.rb
@@ -35,7 +35,13 @@ end
 
 service "rsyslog" do
   provider Chef::Provider::Service::Upstart if node[:platform] == "ubuntu"
-  service_name "syslog" if node[:platform] == "suse"
+  if node[:platform] == "suse"
+    if node[:platform_version].to_f >= 12.3
+        provider Chef::Provider::Service::Systemd
+    else
+        service_name "syslog"
+    end
+  end
   supports :restart => true, :status => true, :reload => true
   running true
   enabled true


### PR DESCRIPTION
This adds some tweaks to the logging, deployer and provisioner cookbooks to
be able to deploy the admin node on openSUSE 12.3

 chef/cookbooks/logging/recipes/server.rb | 8 +++++++-
 1 file changed, 7 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 36fe5284bb2a9413ccbae3d00c1b19a7612ce79c

Crowbar-Release: development
