### PR TITLE
Do not include \n in utils_line

### DIFF
--- a/chef/cookbooks/logging/recipes/server.rb
+++ b/chef/cookbooks/logging/recipes/server.rb
@@ -60,14 +60,14 @@ end
 
 # dropping privileges seems to not allow network ports < 1024.
 # so, don't drop privileges.
-utils_line "#don't drop user privileges to keep network\n  " do
+utils_line "# don't drop user privileges to keep network" do
   action :add
   regexp_exclude '\$PrivDropToUser\s+syslog\s*'
   file "/etc/rsyslog.conf"
   notifies :restart, "service[rsyslog]"
 end
 
-utils_line "#don't drop group privileges to keep network\n  " do
+utils_line "# don't drop group privileges to keep network" do
   action :add
   regexp_exclude '\$PrivDropToGroup\s+syslog\s*'
   file "/etc/rsyslog.conf"


### PR DESCRIPTION
This is just wrong, it shouldn't be needed (and it appears ugly in the
chef output log).
