### PR TITLE
Windows Server 2012 / Hyper-V Server 2012 support [6/9]

### DIFF
--- a/chef/cookbooks/logging/recipes/client.rb
+++ b/chef/cookbooks/logging/recipes/client.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+return if node[:platform] == "windows"
+
 package "rsyslog"
 
 env_filter = " AND environment:#{node[:logging][:config][:environment]}"


### PR DESCRIPTION
## Windows integration required patches in the following areas:
- Ruby 1.9 compatibility as the Windows Chef client is based on Ruby 1.9
- Provisioner barclamp updated for supporting multiple operating systems
- Provisioner barclamp updated for generating Windows unattended.xml files
- TFTP server configuration updated for Windows support
- Crowbar barclamp web UI updated for multiple operating systems support
- NTP support for Windows
- Filters for Linux specific settings on Windows
## Limitations:
- Single Windows image supported. This is due to limitations on the way Windows
  pulls components via TFTP during PXE boot. This issue can be solved in various ways
  that require additional external dependencies that need to be discussed.
- No Nagios and Ganglia clients on Windows
- No IPMI support on Windows
- Windows Administrator password is currently provided in clear text. Needs to be 
  replaced with hash generated by Windows Assesment and Deployment Kit (ADK).
## Additional requirements:
- A Windows image is required to generate the WinPE image used during PXE boot.
  For licensing reasons the image has to be generated by the user/deployer. Scripts
  to automate the instalation of the ADK and the generation of the image are available
  here: http://github.com/adk-tools
  
  chef/cookbooks/logging/recipes/client.rb |    2 ++
  1 file changed, 2 insertions(+)

Crowbar-Pull-ID: 58a2078e8676eb14d4439f36e1ad3e1385f0a21b

Crowbar-Release: pebbles
