### PR TITLE
Rework how we setup logging for Crowbar [3/3]

### DIFF
--- a/bin/gather_logs.sh
+++ b/bin/gather_logs.sh
@@ -43,7 +43,7 @@ sort_by_last() {
     cd "$logdir"
     sshopts=(-q -o 'StrictHostKeyChecking no' 
 	-o 'UserKnownHostsFile /dev/null')
-    logs=(/var/log /etc /opt/dell/crowbar_framework/log)
+    logs=(/var/log /etc)
     logs+=(/var/chef/cache /var/cache/chef /opt/dell/crowbar_framework/db)
     curlargs=(-o /dev/null -D - --connect-timeout 30 --max-time 120)
     [[ $CROWBAR_KEY ]] && curlargs+=(--digest -u "$CROWBAR_KEY")


### PR DESCRIPTION
There are two main changes:

instead of putting stdout/stderr in production.log, we put them in
production.stdout and production.stderr.

we really use production.log to log things, instead of using syslog
which loses the formatting and spams /var/log/messages.

The rationale for using syslog was "distributed setups", but since we
put the logs of chef-client runs in /opt/dell/crowbar_framework anyway,
I don't think this rationale stands.
