### PR TITLE
Add logging and NTP barclamps into the admin node bootstrap. [4/5]

### DIFF
--- a/chef/cookbooks/logging/recipes/client.rb
+++ b/chef/cookbooks/logging/recipes/client.rb
@@ -15,14 +15,9 @@
 
 package "rsyslog"
 
-env_filter = " AND environment:#{node[:logging][:config][:environment]}"
-servers = search(:node, "roles:logging\\-server#{env_filter}")
-
-if servers.nil?
-  servers = []
-else
-  servers = servers.map { |x| x.address.addr }
-end
+# Don't configure this node as a logging client if it is already a server.
+return if node["roles"].include?("ntp-server")
+servers = node[:crowbar][:logging][:servers]
 
 # Disable syslogd in favor of rsyslog on redhat.
 case node[:platform]

--- a/chef/cookbooks/logging/recipes/server.rb
+++ b/chef/cookbooks/logging/recipes/server.rb
@@ -17,7 +17,11 @@
 package "rsyslog"
 
 
-external_servers = node[:logging][:external_servers]
+external_servers = node[:crowbar][:logging][:external_servers]
+unless node[:crowbar][:logging][:servers] &&
+    node[:crowbar][:logging][:servers].include?(node.address.to_s)
+  node.set[:crowbar][:logging][:servers] = [ node.address.to_s ]
+end
 
 # Disable syslogd in favor of rsyslog on suse (presumably desirable
 # for redhat too, but I'm not in a position to test/verify ATM - see

--- a/chef/roles/logging-client/role-template.json
+++ b/chef/roles/logging-client/role-template.json
@@ -1,5 +1,3 @@
 {
-  "environment": "logging-base-config",
-  "mode": "full"
 }
 

--- a/chef/roles/logging-server.rb
+++ b/chef/roles/logging-server.rb
@@ -4,9 +4,6 @@ description "Logging Servier Role - Logging master for the cloud"
 run_list(
          "recipe[logging::server]"
 )
-default_attributes "logging" => {
-  "external_servers" => [ ],
-  "config" => { "environment" => "logging-base-config" }
-}
+default_attributes()
 override_attributes()
 

--- a/chef/roles/logging-server/role-template.json
+++ b/chef/roles/logging-server/role-template.json
@@ -1,5 +1,8 @@
 {
-  "environment": "logging-base-config",
-  "mode": "full"
+    "crowbar": {
+        "logging": {
+            "external_servers": []
+        }
+    }
 }
 

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -27,6 +27,23 @@ barclamp:
   member:
     - crowbar
 
+roles:
+  - name: logging-server
+    jig: chef
+    flags:
+      - bootstrap
+    requires:
+      - dns-client
+      - network-admin
+  - name: logging-client
+    jig: chef
+    flags:
+      - discovery
+    requires:
+      - logging-server
+      - network-admin
+
+
 crowbar:
   layout: 2.0
   order: 40


### PR DESCRIPTION
Fix up the NTP and logging barclamps to allow them to be deployed, and
fix up bugs introduced by the last pull request series.

 chef/cookbooks/logging/recipes/client.rb     |   11 +++--------
 chef/cookbooks/logging/recipes/server.rb     |    6 +++++-
 chef/roles/logging-client/role-template.json |    2 --
 chef/roles/logging-server.rb                 |    5 +----
 chef/roles/logging-server/role-template.json |    7 +++++--
 crowbar.yml                                  |   17 +++++++++++++++++
 6 files changed, 31 insertions(+), 17 deletions(-)

Crowbar-Pull-ID: 3ad87c72b743e6a5474ec33caf2b57249b136059

Crowbar-Release: development
