### PR TITLE
Make role attributes work, and add some to play around with in CB 2.0 [5/8]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -35,6 +35,10 @@ roles:
     requires:
       - dns-client
       - network-admin
+    attribs:
+      - name: logging_server
+        description: "The IP addresses of the server that should get all logging output."
+        map: 'crowbar/logging/servers'
   - name: logging-client
     jig: chef-solo
     flags:
@@ -43,6 +47,8 @@ roles:
       - dns-client
       - logging-server
       - network-admin
+    wants-attribs:
+      - logging_server
 
 
 crowbar:


### PR DESCRIPTION
- Make Attrib.get smart. Instead of passing a blob of JSON, it now
  accepts the object it should try to work with. This centralizes the
  logic around what fields in an object are valid places to get
  attributes from, and will fail hard if you pass it something that
  should not work with the attribute system.
- Add matching Attrib.set methods. This provides an abstract interface
  for setting attributes on objects that matches the use of
  Attrib.get.
- Add some attributes to various nodes to lay the groundwork for
  adding logic to the annealer to make it consiter attribute visibility.
- Numerous trivial cleanups to make things work with the above changes.
  
  crowbar.yml | 6 ++++++
  1 file changed, 6 insertions(+)

Crowbar-Pull-ID: cd953079fcc42015c6552d4b6d190cc54e898308

Crowbar-Release: development
