### PR TITLE
stop processing after logging from remote node

### DIFF
--- a/chef/cookbooks/logging/recipes/server.rb
+++ b/chef/cookbooks/logging/recipes/server.rb
@@ -18,6 +18,7 @@ package "rsyslog"
 
 
 external_servers = node[:logging][:external_servers]
+rsyslog_version = `rsyslogd -v | head -1 | cut -d " " -f 2`
 
 # Disable syslogd in favor of rsyslog on suse (presumably desirable
 # for redhat too, but I'm not in a position to test/verify ATM - see
@@ -54,7 +55,7 @@ template "/etc/rsyslog.d/10-crowbar-server.conf" do
   group "root"
   mode 0644
   source "rsyslog.server.erb"
-  variables(:external_servers => external_servers)
+  variables(:external_servers => external_servers, :rsyslog_version => rsyslog_version)
   notifies :restart, "service[rsyslog]"
 end
 

--- a/chef/cookbooks/logging/templates/default/rsyslog.server.erb
+++ b/chef/cookbooks/logging/templates/default/rsyslog.server.erb
@@ -10,8 +10,12 @@ $UDPServerRun 514
 # split remote logs by hostname
 # stop processing the line after it has been logged
 $template DynaFile,"/var/log/nodes/%HOSTNAME%.log"
-if $fromhost-ip != '127.0.0.1' then ?DynaFile
+if $fromhost-ip != '127.0.0.1' then -?DynaFile
+<% if @rsyslog_version < "7" %>
 & ~
+<% else %>
+& stop
+<% end %>
 
 <% @external_servers.each do |external_server| -%>
 *.* @@<%= external_server %>


### PR DESCRIPTION
After logging from remote machine, stop processing the line, so it is not logged also in local /var/log/messages.

SUSE reference: https://bugzilla.novell.com/show_bug.cgi?id=854418
