### PR TITLE
CB 2: Make all the things use wants-attrib for smart attribute injection. [5/8]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -30,8 +30,6 @@ barclamp:
 roles:
   - name: logging-server
     jig: chef-solo
-    flags:
-      - server
     requires:
       - dns-client
       - network-admin


### PR DESCRIPTION
This pull request series switches the core Crowbar framework to be
smarter about injecting just the attributes that a role declares that
it needs, instead of just smashing everything that could be in scope
together.

 crowbar.yml | 2 --
 1 file changed, 2 deletions(-)

Crowbar-Pull-ID: dccf04341e8a02b81a47fd321efe6c0256033410

Crowbar-Release: development
