### PR TITLE
Replaced barclamp controller initialzer with before filter

### DIFF
--- a/crowbar_framework/app/controllers/logging_controller.rb
+++ b/crowbar_framework/app/controllers/logging_controller.rb
@@ -14,10 +14,6 @@
 # 
 
 class LoggingController < BarclampController
-  def initialize
-    @service_object = LoggingService.new logger
-  end
-  
   def export
     ctime=Time.now.strftime("%Y%m%d-%H%M%S")
     @file = "crowbar-logs-#{ctime}.tar.bz2"
@@ -27,7 +23,10 @@ class LoggingController < BarclampController
     Process.detach(pid) # reap child process automatically; don't leave running    
     redirect_to "/utils?waiting=true&file=#{@file.gsub(/\./,'-DOT-')}"
   end
-  
 
+  protected
+
+  def initialize_service
+    @service_object = LoggingService.new logger
+  end
 end
-


### PR DESCRIPTION
I transfered the service initialize into a before filter. It's a quite dirty practice to overwrite the controller initializer and the way it is done now will result in problems while upgrading to rails 3 or 4.
**This depends on https://github.com/crowbar/barclamp-crowbar/pull/1036**
