### PR TITLE
Rename /etc/rsyslog.d/10-crowbar-client.conf to 99-crowbar-client.conf

### DIFF
--- a/chef/cookbooks/logging/recipes/client.rb
+++ b/chef/cookbooks/logging/recipes/client.rb
@@ -51,7 +51,14 @@ service "rsyslog" do
   action [ :enable, :start ]
 end
 
-template "/etc/rsyslog.d/10-crowbar-client.conf" do
+if File.exists? "/etc/rsyslog.d/10-crowbar-client.conf"
+  # Upgrade path: we used to create that file
+  file "/etc/rsyslog.d/10-crowbar-client.conf" do
+    action :delete
+  end
+end
+
+template "/etc/rsyslog.d/99-crowbar-client.conf" do
   owner "root"
   group "root"
   mode 0644


### PR DESCRIPTION
We want this to be the last config file; for instance, this should be
included after 11-swift.conf. Of course, we could rename 11-swift.conf,
but there might be other files.
